### PR TITLE
Allow JavaMail Session creation to be overridden

### DIFF
--- a/src/main/java/com/threewks/thundr/mail/JavaMailMailer.java
+++ b/src/main/java/com/threewks/thundr/mail/JavaMailMailer.java
@@ -60,7 +60,7 @@ public class JavaMailMailer extends BaseMailer {
 	protected void sendInternal(Map.Entry<String, String> from, Map.Entry<String, String> replyTo, Map<String, String> to, Map<String, String> cc, Map<String, String> bcc, String subject,
 			Object body, List<Attachment> attachments) {
 		try {
-			Session emailSession = Session.getDefaultInstance(new Properties());
+			Session emailSession = getSession();
 
 			Message message = new MimeMessage(emailSession);
 			message.setFrom(emailAddress(from));
@@ -92,6 +92,10 @@ public class JavaMailMailer extends BaseMailer {
 		} catch (MessagingException e) {
 			throw new MailException(e, "Failed to send an email: %s", e.getMessage());
 		}
+	}
+
+	protected Session getSession() {
+		return Session.getDefaultInstance(new Properties());
 	}
 
 	protected void sendMessage(Message message) throws MessagingException {


### PR DESCRIPTION
Allow JavaMail Session creation to be overridden to enable simple extension of JavaMailMailer. This is particularly useful outside of GAE when we need control of smtp host/port and authentication.

e.g. a mailer that sends using gmail would only need to specify the following method, reusing the remaining JavaMailMailer internals.

```
protected Session getSession() {
	Properties props = new Properties();
	props.put("mail.smtp.auth", "true");
	props.put("mail.smtp.starttls.enable", "true");
	props.put("mail.smtp.host", "smtp.gmail.com");
	props.put("mail.smtp.port", "587");

	return Session.getInstance(props,
			new Authenticator() {
				protected PasswordAuthentication getPasswordAuthentication() {
					return new PasswordAuthentication(username, password);
				}
			});
}
``` 