### PR TITLE
#10 ClassCastException when in RouteResolverException is checked

### DIFF
--- a/src/main/java/com/threewks/thundr/Thundr.java
+++ b/src/main/java/com/threewks/thundr/Thundr.java
@@ -17,10 +17,6 @@
  */
 package com.threewks.thundr;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.atomicleopard.expressive.Cast;
 import com.threewks.thundr.configuration.ConfigurationModule;
 import com.threewks.thundr.injection.InjectionContextImpl;
@@ -42,6 +38,10 @@ import com.threewks.thundr.route.RouterModule;
 import com.threewks.thundr.transformer.TransformerModule;
 import com.threewks.thundr.view.ViewResolverNotFoundException;
 import com.threewks.thundr.view.ViewResolverRegistry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  *
@@ -152,18 +152,19 @@ public class Thundr {
 			if (view != null) {
 				viewResolverRegistry.resolve(req, resp, view);
 			}
+		} catch (ViewResolverNotFoundException e) {
+			throw e;
+
 		} catch (RuntimeException e) {
+			Throwable resolveThrowable = e;
+
 			if (Cast.is(e, RouteResolverException.class)) {
 				// unwrap RouteResolverException if it is one
-				e = (RuntimeException) Cast.as(e, RouteResolverException.class).getCause();
-			}
-			if (Cast.is(e, ViewResolverNotFoundException.class)) {
-				// if there was an error finding a view resolver, propagate this
-				throw (ViewResolverNotFoundException) e;
+				resolveThrowable = Cast.as(e, RouteResolverException.class).getCause();
 			}
 			if (resp.isUncommitted()) {
 				try {
-					viewResolverRegistry.resolve(req, resp, e);
+					viewResolverRegistry.resolve(req, resp, resolveThrowable);
 					resp.finaliseHeaders();
 				} catch (ViewResolverNotFoundException exceptionViewNotFound) {
 					throw e;

--- a/src/test/java/com/threewks/thundr/ThundrTest.java
+++ b/src/test/java/com/threewks/thundr/ThundrTest.java
@@ -252,7 +252,7 @@ public class ThundrTest {
 	}
 
 	@Test
-	public void shouldThrowActionExceptionFromViewResolverWhenNoMatchingExceptionResolverFound() {
+	public void shouldThrowActionExceptionFromViewResolverWhenNoMatchingExceptionResolverFoundAndCauseNotRuntimeException() {
 		final RuntimeException expectedException = new RouteResolverException(new Exception("Intentional Checked Exception"), "");
 		thrown.expect(is(expectedException));
 


### PR DESCRIPTION
 * Pulled `ViewResolverNotFoundException` into its own `catch` since there was no need to check instance to just re-throw
 * Pass `Throwable` when attempting to resolve an exception view - still throw original exception if none can be found
